### PR TITLE
Fix layout base and script path

### DIFF
--- a/ControllerExample/Components/Admin/Layout/MainLayout.razor
+++ b/ControllerExample/Components/Admin/Layout/MainLayout.razor
@@ -1,5 +1,9 @@
 ﻿@inherits LayoutComponentBase
 
+<HeadContent>
+    <base href="~/" />
+</HeadContent>
+
 <div class="page">
     <div class="sidebar">
         <NavMenu />
@@ -23,4 +27,5 @@
 </div>
 
 <script src="/_framework/aspnetcore-browser-refresh.js"></script>
-<script src="_framework/blazor.web.js"></script>
+@* Use the server script because components render interactively on the server *@
+<script src="/_framework/blazor.server.js"></script>


### PR DESCRIPTION
## Summary
- include `<base href="~/" />` via `HeadContent` in `MainLayout`
- reference blazor server script using absolute path

## Testing
- `dotnet build ControllerExample/ControllerExample.csproj -c Debug`
- `dotnet test ControllerExample.Tests/ControllerExample.Tests.csproj --no-build` *(fails: NU1301 Unable to load the service index)*


------
https://chatgpt.com/codex/tasks/task_e_6884002e0010832c9524e55eed53c7e9