### PR TITLE
Fix test setup and remove hard-coded base URL

### DIFF
--- a/ControllerExample.Tests/ControllerExample.Tests.csproj
+++ b/ControllerExample.Tests/ControllerExample.Tests.csproj
@@ -4,7 +4,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <ProjectReference Include="../ControllerExample/ControllerExample.csproj" />
   </ItemGroup>
 </Project>

--- a/ControllerExample/Program.cs
+++ b/ControllerExample/Program.cs
@@ -8,12 +8,8 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents(); // Enables SignalR-based interactivity..ahem...
 
 builder.Services.AddControllers();
-builder.Services.AddHttpClient("local", client =>
-{
-    var baseUrl = builder.Configuration["ASPNETCORE_URLS"] ?? "http://localhost:5000";
-    client.BaseAddress = new Uri(baseUrl);
-});
-builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("local"));
+builder.Services.AddHttpClient();
+builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient());
 builder.Services.AddSingleton<WeatherForecastService>();
 
 var app = builder.Build();
@@ -38,3 +34,5 @@ app.MapRazorComponents<App>()
 app.MapControllers();
 
 app.Run();
+
+public partial class Program { }


### PR DESCRIPTION
## Summary
- remove custom HttpClient base address so API calls use the server's actual URL
- add `Microsoft.NET.Test.Sdk` so tests are discovered

## Testing
- `dotnet build ControllerExample.Tests/ControllerExample.Tests.csproj -v minimal`
- `dotnet test ControllerExample.Tests/ControllerExample.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6884cd263f30832cbcfdbde0f32cafb6